### PR TITLE
Facets@0.4.1

### DIFF
--- a/facets/README.md
+++ b/facets/README.md
@@ -6,35 +6,21 @@ Read more: [https://github.com/mskcc/facets/](https://github.com/mskcc/facets/)
 
 ## Usage
 
-The typical command for running the pipeline is as follows:
-
-```
-nextflow run wes-postproc/modules/facets --input input.txt -profile cluster,singularity
-```
-
 Mandatory arguments:
 ```
-    --input         Tab delimited file (no header), with paths to following files:
-                    tumor_ID    normal_ID    tumor.bam    normal.bam    target.dbsnp
+    --pileup        Pileup file produced by snp-pileup (.bc.gz)
+    --out_prefix    Output prefix
 ```
 
 Optional arguments:
 ```
-    --snp_pileup    Full path to the folder containing the snp_pileup files (you might want to use this when re-running facets)
-    --summaryPrefix Prefix for the summary files [all.geneCN]
-    --q             (snp-pileup) Sets the minimum threshold for mapping quality [1]
-    --Q             (snp-pileup) Sets the minimum threshold for base quality [13]
-    --r             (snp-pileup) Comma separated list of minimum read counts for a position to be output [25,0]
-    --d             (snp-pileup) Sets the maximum depth [1000]
     --genome        Genome build (b37, GRCh37, hg19, mm9, mm10, GRCm38, hg38). [hg38]
     --seed          [1234]
     --snp_nbhd      Window size [250]
-    --minNDepth     Minimum depth in normal to keep the position [25]
-    --maxNDepth     Maximum depth in normal to keep the position [1000]
-    --pre_cval      Pre-processing critical value [cval1 - 50]
-    --cval1         Critical value for estimating diploid log Ratio [200]
-    --cval2         Starting critical value for segmentation (increases by 25 until success) [cval1 - 50]
-    --max_cval      Maximum critical value for segmentation (increases by 25 until success) [5000]
+    --minNDepth     Minimum depth in normal to keep the position [5]
+    --maxNDepth     Maximum depth in normal to keep the position [500]
+    --pre_cval      Pre-processing critical value [80]
+    --cval          Critical value for estimating diploid log Ratio [200]
     --min_nhet      Minimum number of heterozygote snps in a segment used for bivariate t-statistic during clustering of segment [25]
     --unmatched     Is it unmatched? [FALSE]
     --minGC         Min GC of position [0]
@@ -43,41 +29,24 @@ Optional arguments:
 
 ## Output
 ```
-./facets_out/snp_pileup .................. pileup files for every sample.
-    {tumor_id}__{normal_id}__q{params.q}_Q{params.Q}_d{params.maxNDepth}_r{params.r}.bc.gz
+ .cncf.pdf ...... genome-wide profile. Figures:
+                  log-ratio: logR  with  chromosomes  alternating  in  blue  and gray. The green line indicates the median logR in the sample. The purple line indicates the logR of the diploid state.
+                  log-odds-ratio: Segment means are ploted in red lines.
+                  copy number (em): plots the total (black) and minor (red) copy number for each segment.
+                  cf-em: shows the associated cellular fraction (cf). Dark blue indicates high cf. Light blue indicates low cf. Beige indicates a normal segment (total=2,minor=1).
+ .cncf.txt ...... FACETS result table. The columns are:
+                  chrom: the chromosome to which the segment belongs.seg: the segment number.
+                  num.mark: the number of SNPs in the segment.
+                  nhet: the number of SNPs that are deemed heterozygous.
+                  cnlr.median: the median log-ratio of the segment.
+                  mafR: the log-odds-ratio summary for the segment (close to zero means the alleles are in balance).
+                  segclust: the segment cluster to which segment belongs.
+                  cnlr.median.clust: the median log-ratio of the segment cluster.
+                  mafR.clust: the log-odds-ratio summary for the segment cluster.
+                  cf.em: the cellular fraction of the segment.
+                  tcn.em: the total copy number of the segment.
+                  lcn.em: the minor copy number of the segment.
+ .out ........... result summary file and log
+ .Rdata ......... FACETS R session
 
-
-
-./facets_out/cval1{params.cval1} .......... FACETS results for every sample.
-    {tumor_id}__{normal_id}.cncf.pdf ...... genome-wide profile. Figures:
-                                            log-ratio: logR  with  chromosomes  alternating  in  blue  and gray. The green line indicates the median logR in the sample. The purple line indicates the logR of the diploid state.
-                                            log-odds-ratio: Segment means are ploted in red lines.
-                                            copy number (em): plots the total (black) and minor (red) copy number for each segment.
-                                            cf-em: shows the associated cellular fraction (cf). Dark blue indicates high cf. Light blue indicates low cf. Beige indicates a normal segment (total=2,minor=1).
-    {tumor_id}__{normal_id}.cncf.txt ...... FACETS result table. The columns are:
-                                            chrom: the chromosome to which the segment belongs.seg: the segment number.
-                                            num.mark: the number of SNPs in the segment.
-                                            nhet: the number of SNPs that are deemed heterozygous.
-                                            cnlr.median: the median log-ratio of the segment.
-                                            mafR: the log-odds-ratio summary for the segment (close to zero means the alleles are in balance).
-                                            segclust: the segment cluster to which segment belongs.
-                                            cnlr.median.clust: the median log-ratio of the segment cluster.
-                                            mafR.clust: the log-odds-ratio summary for the segment cluster.
-                                            cf.em: the cellular fraction of the segment.
-                                            tcn.em: the total copy number of the segment.
-                                            lcn.em: the minor copy number of the segment.
-    {tumor_id}__{normal_id}.logR.pdf ...... genome-wide profile log-ratio only.
-    {tumor_id}__{normal_id}.out ........... result summary file and log
-    {tumor_id}__{normal_id}.Rdata ......... FACETS R session
-
-```
-
-## Fetching the singularity container
-```
-bash scripts/fetch_image.sh
-```
-
-## Fetching resource files
-```
-bash scripts/fetch_resources.sh
 ```

--- a/facets/main.nf
+++ b/facets/main.nf
@@ -49,7 +49,7 @@ params.publish_dir = ""  // set to empty string will disable publishDir
 params.help = null
 
 // tool specific parmas go here, add / change as needed
-params.tumor_id       = null
+params.out_prefix     = null
 params.pileup         = null
 params.genome         = 'hg38'
 params.snp_nbhd       = 500
@@ -74,8 +74,8 @@ The typical command for running the pipeline is as follows:
     nextflow run facets/main.nf --pileup <snp-pileup.bc.gz>
 
 Mandatory arguments:
-    --tumor_id      Tumor ID
     --pileup        Pileup file produced by snp-pileup (.bc.gz)
+    --out_prefix    Output prefix
 
 Optional arguments:
     --genome        Genome build (b37, GRCh37, hg19, mm9, mm10, GRCm38, hg38). [${params.genome}]
@@ -94,16 +94,14 @@ Optional arguments:
 
 if (params.help) exit 0, helpMessage()
 
+// Validate inputs
+if(params.out_prefix == null) error "Missing mandatory '--out_prefix' parameter"
+
 log.info ""
-log.info "tumor_id=${params.tumor_id}"
+log.info "pileup=${params.out_prefix}"
 log.info "pileup=${params.pileup}"
 log.info "genome=${params.genome}"
 log.info ""
-
-
-// Validate inputs
-if(params.tumor_id == null) error "Missing mandatory '--tumor_id' parameter"
-if(params.pileup == null) error "Missing mandatory '--pileup' parameter"
 
 
 process facets {
@@ -124,10 +122,10 @@ process facets {
   shell:
     '''
         #run facets
-        facetsRun.R --seed !{params.seed} --minNDepth !{params.minNDepth} --maxNDepth !{params.maxNDepth} --snp_nbhd !{params.snp_nbhd} --minGC !{params.minGC} --maxGC !{params.maxGC} --cval !{params.cval} --pre_cval !{params.pre_cval} --genome !{params.genome} --min_nhet !{params.min_nhet} --outPrefix !{params.tumor_id} --tumorName !{params.tumor_id} !{pileup}
+        facetsRun.R --seed !{params.seed} --minNDepth !{params.minNDepth} --maxNDepth !{params.maxNDepth} --snp_nbhd !{params.snp_nbhd} --minGC !{params.minGC} --maxGC !{params.maxGC} --cval !{params.cval} --pre_cval !{params.pre_cval} --genome !{params.genome} --min_nhet !{params.min_nhet} --outPrefix !{params.out_prefix} --tumorName !{params.out_prefix} !{pileup}
         
         #fetch results (cncf and plot can be missing from facets results, but if produced both will be available)
-        facetsResults.sh -s !{params.tumor_id}.out $(if [[ -f !{params.tumor_id}.cncf.txt && -f !{params.tumor_id}.cncf.pdf ]]; then echo -c !{params.tumor_id}.cncf.txt -p !{params.tumor_id}.cncf.pdf; fi)
+        facetsResults.sh -s !{params.out_prefix}.out $(if [[ -f !{params.out_prefix}.cncf.txt && -f !{params.out_prefix}.cncf.pdf ]]; then echo -c !{params.out_prefix}.cncf.txt -p !{params.out_prefix}.cncf.pdf; fi)
     '''
 }
 

--- a/facets/main.nf
+++ b/facets/main.nf
@@ -29,7 +29,7 @@
 /* this block is auto-generated based on info from pkg.json where   */
 /* changes can be made if needed, do NOT modify this block manually */
 nextflow.enable.dsl = 2
-version = '0.4.0'
+version = '0.4.1'
 
 container = [
     'ghcr.io': 'ghcr.io/icgc-argo-structural-variation-cn-wg/icgc-argo-sv-copy-number.facets'

--- a/facets/pkg.json
+++ b/facets/pkg.json
@@ -1,6 +1,6 @@
 {
     "name": "facets",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "facets tool",
     "main": "main.nf",
     "deprecated": false,

--- a/facets/tests/checker.nf
+++ b/facets/tests/checker.nf
@@ -34,7 +34,7 @@
 /* this block is auto-generated based on info from pkg.json where   */
 /* changes can be made if needed, do NOT modify this block manually */
 nextflow.enable.dsl = 2
-version = '0.4.0'
+version = '0.4.1'
 
 container = [
     'ghcr.io': 'ghcr.io/icgc-argo-structural-variation-cn-wg/icgc-argo-sv-copy-number.facets'

--- a/facets/tests/checker.nf
+++ b/facets/tests/checker.nf
@@ -48,7 +48,7 @@ params.container_version = ""
 params.container = ""
 
 // tool specific parmas go here, add / change as needed
-params.tumor_id = ""
+params.out_prefix = ""
 params.pileup = ""
 params.genome = ""
 params.expected_output = ""
@@ -78,7 +78,7 @@ process file_smart_diff {
 workflow checker {
   take:
     pileup
-    tumor_id
+    out_prefix
     genome
     expected_output
 
@@ -97,7 +97,7 @@ workflow checker {
 workflow {
   checker(
     file(params.pileup),
-    params.tumor_id,
+    params.out_prefix,
     params.genome,
     file(params.expected_output)
   )

--- a/facets/tests/test-job-1.json
+++ b/facets/tests/test-job-1.json
@@ -1,6 +1,6 @@
 {
     "pileup": "input/test.bc.gz",
-    "tumor_id": "test",
+    "out_prefix": "test",
     "genome": "hg19",
     "expected_output": "expected/expected.out",
     "publish_dir": "outdir",


### PR DESCRIPTION
Updated `main.nf` to exclude mandatory pileup parameter causing error in a workflow.
Changed parameter `tumor_id` to `out_prefix` (more intuitive).
Updated readme.